### PR TITLE
cobbleverse: add backup sidecar; renkko: disable PCIe ASPM

### DIFF
--- a/renkko/games/cobbleverse/deployment.yaml
+++ b/renkko/games/cobbleverse/deployment.yaml
@@ -76,11 +76,44 @@ spec:
           requests:
             cpu: 500m
             memory: 9Gi
+      - image: itzg/mc-backup
+        name: backup
+        env:
+        - name: ENABLE_SAVE_ALL
+          value: "false"
+        - name: BACKUP_INTERVAL
+          value: "30m"
+        - name: PRUNE_BACKUPS_DAYS
+          value: "2"
+        - name: SRC_DIR
+          value: /data
+        - name: DEST_DIR
+          value: /backups
+        - name: EXCLUDES
+          value: "*.jar,cache,logs,*.tmp,mods,libraries,versions,resourcepacks"
+        - name: TZ
+          value: "America/Chicago"
+        volumeMounts:
+        - name: data
+          mountPath: /data
+          readOnly: true
+        - name: backups
+          mountPath: /backups
+        resources:
+          limits:
+            cpu: "2"
+            memory: 1Gi
+          requests:
+            cpu: 50m
+            memory: 128Mi
       volumes:
       - name: data
         persistentVolumeClaim:
           claimName: minecraft-cobbleverse
           readOnly: false
+      - name: backups
+        persistentVolumeClaim:
+          claimName: cobbleverse-backups
       - name: server-properties
         configMap:
           name: cobbleverse-server-properties
@@ -96,5 +129,19 @@ spec:
   resources:
     requests:
       storage: 25Gi
+  storageClassName: rook-rbd
+  volumeMode: Filesystem
+
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: cobbleverse-backups
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 120Gi
   storageClassName: rook-rbd
   volumeMode: Filesystem

--- a/talos/renkko/talconfig.yaml
+++ b/talos/renkko/talconfig.yaml
@@ -61,6 +61,11 @@ patches:
           enabled: true
           forwardKubeDNSToHost: true
   - |-
+    machine:
+      install:
+        extraKernelArgs:
+          - pcie_aspm=off
+  - |-
     cluster:
       proxy:
         disabled: true


### PR DESCRIPTION
## Why

renkko hard-resets spontaneously (2026-06-25, 08-02, 08-05) — each time an XFS journal replay on boot and no panic logged. The 08-05 reset destroyed Cobblemon player data for 3 players.

Cobblemon writes its live file and its `.old` backup ~1ms apart, so a power loss zeroes both. Vanilla `playerdata` survived because its `.dat_old` is a minutes-older generation already flushed to disk.

## Changes

**Backup sidecar** (`itzg/mc-backup`, 30m interval, 2 day retention, 120Gi PVC). Neither Minecraft nor any of the 113 modpack mods provides backups. RCON stays disabled because `rcon.password` would have to be committed to this public repo, so `ENABLE_SAVE_ALL=false` relies on server autosave.

**`pcie_aspm=off`** — the CIX P1 firmware advertises no AER/LTR/DPC support (`_OSC: platform does not support [... PME AER LTR DPC]`), so PCIe faults can be neither reported nor contained and take the box down silently. Radxa ship ASPM disabled on this SoC for the same reason.

Takes effect on `talosctl upgrade` (bootloader rewrite), not a plain reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)