### PR TITLE
Revert renkko pcie_aspm=off kernel arg

### DIFF
--- a/talos/renkko/talconfig.yaml
+++ b/talos/renkko/talconfig.yaml
@@ -61,11 +61,6 @@ patches:
           enabled: true
           forwardKubeDNSToHost: true
   - |-
-    machine:
-      install:
-        extraKernelArgs:
-          - pcie_aspm=off
-  - |-
     cluster:
       proxy:
         disabled: true


### PR DESCRIPTION
`talhelper genconfig` fails outright on main after #96:

```
* v1alpha1.Config: 1 error occurred:
* install.extraKernelArgs and install.grubUseUKICmdline can't be used together
```

Talos v1.12 rejects `install.extraKernelArgs` alongside `grubUseUKICmdline`, which talhelper sets by default — so this node's config cannot be regenerated at all.

## Why not just use a schematic

Reworking it as an Image Factory schematic generates a valid image, but the wrong one. The node runs three system extensions: iscsi-tools v0.2.0, util-linux-tools 2.41.1, and the custom **r8127** RTL8127 10GbE driver (11.015.00) from the talos-rtl-driver repo.

Image Factory cannot carry custom/private extensions, so a factory-schematic image would silently strip all three on upgrade.

Adding kernel args to this node requires rebuilding a custom installer with the Talos imager bundling all three extensions. Backing out until that's done. The backup sidecar from #96/#97 is unaffected and stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)