### PR TITLE
renkko: move to a stock Image Factory installer with pcie_aspm=off

### DIFF
--- a/talos/renkko/talconfig.yaml
+++ b/talos/renkko/talconfig.yaml
@@ -18,6 +18,14 @@ nodes:
     ipAddress: 10.1.0.230
     controlPlane: true
     installDisk: /dev/nvme0n1
+    schematic:
+      customization:
+        extraKernelArgs:
+          - pcie_aspm=off
+        systemExtensions:
+          officialExtensions:
+            - siderolabs/iscsi-tools
+            - siderolabs/util-linux-tools
     networkInterfaces:
       - interface: enp1s0
         addresses:


### PR DESCRIPTION
RTL8127A support landed in mainline `r8169` in **Linux 6.16**, and this node already runs on it:

```
enp1s0  productID 0x8127  vendorID 0x10ec   driver: r8169  6.18.18-talos
        linkState: true   speedMbit: 5000   duplex: Full
```

The custom `r8127` extension never loaded — the running cmdline has `module.sig_enforce=1` and no `modprobe.blacklist=r8169`. It can go, which retires the talos-rtl-driver maintenance burden entirely.

## What this changes

With only official extensions left, Image Factory can build this node's image:

| | |
|---|---|
| Old | `376567988a…` (empty default schematic) |
| New | `0e31dad535…` (iscsi-tools + util-linux-tools + `pcie_aspm=off`) |

`pcie_aspm=off` targets the spontaneous hard resets — the CIX P1 firmware advertises no AER/LTR/DPC, so PCIe faults are neither reportable nor containable.

It also realigns `install.image`, which pointed at the extension-less default schematic while three extensions were actually installed — so any plain `talosctl upgrade` would have silently stripped them.

Staying on v1.12.6; the Talos version bump is a separate change so the kernel isn't a second variable while we're chasing the resets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)